### PR TITLE
Fix/port setting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### 2.2.0
+
+- fixed bug with the `setPort` methods
+- added `setUnoPort` method to `Unoserver` class to set the libreoffice port
+- added the new unoserver v2.1 `--input-filter` & `--output-filter` options with the `setInputFilter` & `setOutputFilter` methods in the `Unoserver` class
+
 #### 2.1.0
 
 - fix: wrong mapping for filter in `Unoconverter` class command argument map

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const { Unoserver } = require("@docwagen/unoserver-node");
 const unoserver = new Unoserver(true);
 const unoServerProcess = unoserver
   .setServerInterface("127.0.0.1")
-  .setPort("2003")
+  .setPort(2003)
   .makeDaemon()
   .run();
 ```
@@ -45,7 +45,9 @@ The following attributes can be set (their descriptions are mostly from the [uno
 
 - **_port_**: the port used by the XMLRPC server. This defaults to "2003".
 
-- **_unoInterface_**: the interface used by the LibreOffice server. Defaults to "2002".
+- **_unoInterface_**: the interface used by the LibreOffice server. Defaults to "127.0.0.1".
+
+- **_unoPort_**: the port used by the LibreOffice server. Defaults to "2002"
 
 - **_daemon_**: attribute to run unoserver as a daemon. This is the only attribute that does not have a direct setter method. The `makeDaemon()` method sets it internally.
 
@@ -86,12 +88,17 @@ const { stdout, stderr } = await new Unoconverter(true)
   .setConvertTo("pdf")
   .setInFile("README.md")
   .setOutFile("readme.pdf")
+  .setPort(2003)
   .execCmd();
 ```
 
 The server must be running before this command is executed. The following attributes are available:
 
 - **_convertTo_**: The file type/extension of the result output file (ex pdf). Required when using stdout.
+
+- **_inputFilter_**: The LibreOffice input filter to use (ex 'writer8'), if autodetect fails
+
+- **_outputFilter_**: The export filter to be used for conversions
 
 - **_filter_**: The export filter to use when converting. It is selected automatically if not specified.
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ The server must be running before this command is executed. The following attrib
 
 - **_convertTo_**: The file type/extension of the result output file (ex pdf). Required when using stdout.
 
-- **_inputFilter_**: The LibreOffice input filter to use (ex 'writer8'), if autodetect fails
+- **_inputFilter_**: The LibreOffice input filter to use (ex 'writer8'), if autodetect fails. This works for the newer unoserver v2.1.
 
-- **_outputFilter_**: The export filter to be used for conversions
+- **_outputFilter_**: The export filter to be used for conversions. It is selected automatically if not specified. This works for the newer unoserver v2.1.
 
-- **_filter_**: The export filter to use when converting. It is selected automatically if not specified.
+- **_filter_**: The export filter to use when converting. Deprecated alias for **outputFilter**. Stick with the `setFilter` method for old unoserver versions.
 
 - **_filterOption_**: Pass an option for the export filter, in name=value format. Use true/false for boolean values. The unoserver library supports repeating this flag for multiple options, this can be achieved by chaining the `addFilterOption(name, value)` method as many times as the number of filter options desired
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docwagen/unoserver-node",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "NodeJS Unoserver Wrapper to convert between different document formats",
   "main": "src/index",
   "scripts": {

--- a/src/core/BaseService.js
+++ b/src/core/BaseService.js
@@ -42,6 +42,16 @@ class BaseService {
   }
 
   /**
+   * Sets the port used by the server, defaults to "2003"
+   * @param {String} port
+   * @returns self
+   */
+  setPort(port) {
+    this._inputArgs["port"] = Number.parseInt(port);
+    return this;
+  }
+
+  /**
    * Set callback function to be run when the child process closes
    * i.e. the process's stdio streams have been closed.
    * The callback signature must be (result, error) => {...}
@@ -98,6 +108,9 @@ class BaseService {
           // remove surrounding whitespace, attempt to remove quotes
           let argString = String(argValue).trim().replace(/'|"/g, "");
           cmdArgs.push(actualArg, `'${argString}'`);
+          break;
+        case "number":
+          cmdArgs.push(actualArg, argValue);
           break;
         default:
           cmdArgs.push(actualArg, String(argValue));

--- a/src/core/Unocompare.js
+++ b/src/core/Unocompare.js
@@ -35,16 +35,6 @@ class Unocompare extends BaseService {
   }
 
   /**
-   * Sets the port used by the server, defaults to "2002"
-   * @param {String} port
-   * @returns self
-   */
-  setPort(port) {
-    this._inputArgs["port"] = port;
-    return this;
-  }
-
-  /**
    * Sets the host location. This determines the handling of files and can only be one of three values -
    * `auto`, `remote`, and `local`. If you run the client on the same machine as the server, it can be set to `local`,
    * and the files are sent as paths. If they are different machines, it is `remote` and the files are sent as binary data.

--- a/src/core/Unoconverter.js
+++ b/src/core/Unoconverter.js
@@ -31,7 +31,7 @@ class Unoconverter extends BaseService {
   }
 
   /**
-   * Sets the LibreOffice input filter to be used if autodetect fails
+   * Sets the LibreOffice input filter to be used if autodetect fails. New for unoserver v2.1
    * @param {String} inputFilter
    * @returns self
    */
@@ -41,7 +41,7 @@ class Unoconverter extends BaseService {
   }
 
   /**
-   * Sets the export filter to be used for the conversion
+   * Sets the export filter to be used for the conversion. New for unoserver v2.1
    * @param {String} outputFilter
    * @returns self
    */
@@ -51,9 +51,8 @@ class Unoconverter extends BaseService {
   }
 
   /**
-   * The export filter to use when converting.
+   * The export filter to use when converting. Deprecated alias for `--output-filter`
    * It is selected automatically if not specified.
-   * Prefer the `setOuputFilter` method to this
    * @param {String} filter
    * @returns self
    */

--- a/src/core/Unoconverter.js
+++ b/src/core/Unoconverter.js
@@ -4,6 +4,8 @@ class Unoconverter extends BaseService {
   _BASE_CMD = "unoconvert";
   _CMD_ARGS_MAP = {
     convertTo: "--convert-to",
+    inputFilter: "--input-filter",
+    outputFilter: "--output-filter",
     filter: "--filter",
     filterOption: "--filter-option",
     host: "--host",
@@ -29,8 +31,29 @@ class Unoconverter extends BaseService {
   }
 
   /**
+   * Sets the LibreOffice input filter to be used if autodetect fails
+   * @param {String} inputFilter
+   * @returns self
+   */
+  setInputFilter(inputFilter) {
+    this._inputArgs.inputFilter = inputFilter;
+    return this;
+  }
+
+  /**
+   * Sets the export filter to be used for the conversion
+   * @param {String} outputFilter
+   * @returns self
+   */
+  setOutputFilter(outputFilter) {
+    this._inputArgs.outputFilter = outputFilter;
+    return this;
+  }
+
+  /**
    * The export filter to use when converting.
    * It is selected automatically if not specified.
+   * Prefer the `setOuputFilter` method to this
    * @param {String} filter
    * @returns self
    */
@@ -64,16 +87,6 @@ class Unoconverter extends BaseService {
   }
 
   /**
-   * Sets the port used by the server, defaults to "2002"
-   * @param {String} port
-   * @returns self
-   */
-  setPort(port) {
-    this._inputArgs.port = port;
-    return this;
-  }
-
-  /**
    * Sets the host location. This determines the handling of files and can only be one of three values -
    * `auto`, `remote`, and `local`. If you run the client on the same machine as the server, it can be set to `local`,
    * and the files are sent as paths. If they are different machines, it is `remote` and the files are sent as binary data.
@@ -96,7 +109,7 @@ class Unoconverter extends BaseService {
    * @returns self
    */
   setInFile(inFile) {
-    this._inputArgs.inFile = inFile;
+    this._inputArgs.inFile = `"${inFile.trim()}"`;
     return this;
   }
 
@@ -106,7 +119,7 @@ class Unoconverter extends BaseService {
    * @returns self
    */
   setOutFile(outFile) {
-    this._inputArgs.outFile = outFile;
+    this._inputArgs.outFile = `"${outFile.trim()}"`;
     return this;
   }
 

--- a/src/core/Unoserver.js
+++ b/src/core/Unoserver.js
@@ -5,6 +5,7 @@ class Unoserver extends BaseService {
     serverInterface: "--interface",
     port: "--port",
     unoInterface: "--uno-interface",
+    unoPort: "--uno-port",
     daemon: "--daemon",
     libreOfficePath: "--executable",
     libreOfficeUserProfilePath: "--user-installation",
@@ -25,22 +26,22 @@ class Unoserver extends BaseService {
   }
 
   /**
-   * Set the port used by the XMLRPC server. This defaults to "2003"
-   * @param {String} port
-   * @returns self
-   */
-  setPort(port) {
-    this._inputArgs["port"] = port;
-    return this;
-  }
-
-  /**
-   * Sets the interface used by the LibreOffice server. Defaults to "2002"
+   * Sets the interface used by the LibreOffice server. Defaults to "127.0.0.1"
    * @param {String} unoInterface
    * @returns self
    */
   setUnoInterface(unoInterface) {
     this._inputArgs["unoInterface"] = unoInterface;
+    return this;
+  }
+
+  /**
+   * Sets the port used by the LibreOffice server. Defaults to "2002"
+   * @param {String} unoPort
+   * @returns self
+   */
+  setUnoPort(unoPort) {
+    this._inputArgs["unoPort"] = Number.parseInt(unoPort);
     return this;
   }
 
@@ -75,7 +76,7 @@ class Unoserver extends BaseService {
 
   /**
    * Sets the path to a file that the LibreOffice Process ID will be written to.
-   * If unoserver is run as a daemon, this file will nt be deleted when unoserver exits
+   * If unoserver is run as a daemon, this file will not be deleted when unoserver exits
    * @param {String} processIdFile
    * @returns self
    */


### PR DESCRIPTION
- fixed bug with the `setPort` methods
- added `setUnoPort` method to `Unoserver` class to set the libreoffice port
- added the new unoserver v2.1 `--input-filter` & `--output-filter` options with the `setInputFilter` & `setOutputFilter` methods in the `Unoserver` class
- updated the README and CHANGELOG files